### PR TITLE
以 #remodifier/weapon 標籤統一管理需套用詞綴的武器

### DIFF
--- a/src/main/java/org/yunxi/remodifier/common/config/toml/modifiers/WeaponModifiersConfig.java
+++ b/src/main/java/org/yunxi/remodifier/common/config/toml/modifiers/WeaponModifiersConfig.java
@@ -25,7 +25,7 @@ public class WeaponModifiersConfig {
         ATTRIBUTES = BUILDER.comment("The attribute of the modifier has. One modifier can have multiple attributes. Use ';' to split different attributes").defineList("ATTRIBUTES", Lists.newArrayList(), o -> true);
         AMOUNTS = BUILDER.comment("The amount used to calculate the attribute effect. Also can be multiple. Use ';' to split").defineList("AMOUNTS", Lists.newArrayList(), o -> true);
         OPERATIONS_IDS = BUILDER.comment("The operation ID of the attribute calculation. Can be three values: 0,1,2. 0 is ADDITION. 1 is MULTIPLY_BASE. 2 is MULTIPLY_TOTAL. you can refer to the calculation of the attributes already in the game").defineList("OPERATIONS_IDS", Lists.newArrayList(), o -> true);
-        WHETHER_OR_NOT_WEAPON_USE_TOOL_MODIFIERS = BUILDER.comment("When enabled, the registries of weapon modifiers will be ignored and your weapon items will use tool modifiers.").define("WhetherOrNotCuriosUseArmorModifiers", true);
+        WHETHER_OR_NOT_WEAPON_USE_TOOL_MODIFIERS = BUILDER.comment("When enabled, the registries of weapon modifiers will be ignored and your weapon items will use tool modifiers.").define("WhetherOrNotWeaponUseToolModifiers", true);
 
         BUILDER.pop();
         CONFIG = BUILDER.build();

--- a/src/main/java/org/yunxi/remodifier/common/config/toml/modifiers/WeaponModifiersConfig.java
+++ b/src/main/java/org/yunxi/remodifier/common/config/toml/modifiers/WeaponModifiersConfig.java
@@ -17,7 +17,7 @@ public class WeaponModifiersConfig {
 
     static {
         ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
-        BUILDER.push("Modifiers for tools");
+        BUILDER.push("Modifiers for weapons");
         BUILDER.comment("This configuration file is based on index. it means, 'legendary' -> '30' ->'generic.attack_damage;generic.attack_speed' -> '0.15;0.1' -> '2;2' is the first index, and in it, 'generic.attack_damage' -> '0.15' -> '2', 'generic.attack_speed' -> '0.1' -> '2'", "You may need to make a resource pack to save the customization-required translation key for the attributes if the mod author didn't do that, or your customization on other mods' attribute may not look well", "A hint on the translation key format: attribute.modxxx.attributexxx, e.g. attribute.minecraft.generic.attack_damage");
         NAMES = BUILDER.comment("The name of the modifier").defineList("NAMES", Lists.newArrayList(), o -> true);
         WEIGHTS = BUILDER.comment("The weight of the modifier in the modifiers pool").defineList("WEIGHTS", Lists.newArrayList(), o -> true);

--- a/src/main/java/org/yunxi/remodifier/common/modifier/ModifierHandler.java
+++ b/src/main/java/org/yunxi/remodifier/common/modifier/ModifierHandler.java
@@ -33,11 +33,24 @@ public class ModifierHandler {
     public static Modifier rollModifier(ItemStack stack, Random random) {
         if (!canHaveModifiers(stack)) return null;
         if (!CuriosModifiersConfig.WHETHER_OR_NOT_CURIOS_USE_ARMOR_MODIFIERS.get() && Modifiers.curioPool.isApplicable.test(stack)) return Modifiers.curioPool.roll(stack, random);
-        if (Modifiers.toolPool.isApplicable.test(stack)) return Modifiers.toolPool.roll(stack, random);
+
+        boolean isTool = Modifiers.toolPool.isApplicable.test(stack);
+        boolean isWeapon = !WeaponModifiersConfig.WHETHER_OR_NOT_WEAPON_USE_TOOL_MODIFIERS.get() && Modifiers.weaponPool.isApplicable.test(stack);
+
+        if (isTool && isWeapon) {
+            // Randomly select one pool, if not drawn, use the other pool
+            ModifierPool firstPool = random.nextBoolean() ? Modifiers.toolPool : Modifiers.weaponPool;
+            ModifierPool secondPool = (firstPool == Modifiers.toolPool) ? Modifiers.weaponPool : Modifiers.toolPool;
+            
+            Modifier modifier = firstPool.roll(stack, random);
+            return modifier != null ? modifier : secondPool.roll(stack, random);
+        }
+        if (isTool) return Modifiers.toolPool.roll(stack, random);
+        if (isWeapon) return Modifiers.weaponPool.roll(stack, random);
+
+        if (Modifiers.armorPool.isApplicable.test(stack)) return Modifiers.armorPool.roll(stack, random);
         if (Modifiers.bowPool.isApplicable.test(stack)) return Modifiers.bowPool.roll(stack, random);
         if (Modifiers.shieldPool.isApplicable.test(stack)) return Modifiers.shieldPool.roll(stack, random);
-        if (Modifiers.armorPool.isApplicable.test(stack)) return Modifiers.armorPool.roll(stack, random);
-        if (Modifiers.weaponPool.isApplicable.test(stack)) return Modifiers.weaponPool.roll(stack, random);
         return null;
     }
 

--- a/src/main/java/org/yunxi/remodifier/common/modifier/Modifiers.java
+++ b/src/main/java/org/yunxi/remodifier/common/modifier/Modifiers.java
@@ -6,9 +6,11 @@ import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.*;
 import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraft.tags.ItemTags;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.yunxi.remodifier.Remodifier;
+import org.yunxi.remodifier.common.util.ModTags;
 import org.yunxi.remodifier.common.config.toml.ReModifierConfig;
 import org.yunxi.remodifier.common.config.toml.modifiers.*;
 
@@ -31,18 +33,20 @@ public class Modifiers {
     public static final ModifierPool armorPool = new ModifierPool(stack -> stack.getItem() instanceof ArmorItem || CuriosModifiersConfig.WHETHER_OR_NOT_CURIOS_USE_ARMOR_MODIFIERS.get() && Remodifier.CURIO_PROXY.isModifiableCurio(stack));
 
     public static final ModifierPool toolPool = new ModifierPool(stack -> {
-        Item item = stack.getItem();
-        if (WeaponModifiersConfig.WHETHER_OR_NOT_WEAPON_USE_TOOL_MODIFIERS.get() && item instanceof SwordItem) return true;
-        return item instanceof DiggerItem;
+        if (WeaponModifiersConfig.WHETHER_OR_NOT_WEAPON_USE_TOOL_MODIFIERS.get() && isValidWeapon(stack)) return true;
+        return stack.getItem() instanceof DiggerItem;
     });
 
     public static final ModifierPool weaponPool = new ModifierPool(stack -> {
-        Item item = stack.getItem();
         if (!WeaponModifiersConfig.WHETHER_OR_NOT_WEAPON_USE_TOOL_MODIFIERS.get()) {
-            return item instanceof SwordItem;
+            return isValidWeapon(stack);
         }
         return false;
     });
+
+    public static boolean isValidWeapon(ItemStack item) {
+        return item.is(ModTags.Items.WEAPON_ITEMS);
+    }
 
     public static final ModifierPool bowPool = new ModifierPool(stack -> stack.getItem() instanceof ProjectileWeaponItem);
 

--- a/src/main/java/org/yunxi/remodifier/common/util/ModTags.java
+++ b/src/main/java/org/yunxi/remodifier/common/util/ModTags.java
@@ -1,0 +1,17 @@
+package org.yunxi.remodifier.common.util;
+
+import org.yunxi.remodifier.Remodifier;
+import net.minecraft.world.item.Item;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.resources.ResourceLocation;
+
+public class ModTags {
+    public static class Items {
+        private static TagKey<Item> createTag(String name) {
+            return ItemTags.create(ResourceLocation.fromNamespaceAndPath(Remodifier.MODID, name));
+        }
+
+        public static final TagKey<Item> WEAPON_ITEMS = createTag("weapon");
+    }
+}

--- a/src/main/resources/data/remodifier/tags/items/weapon.json
+++ b/src/main/resources/data/remodifier/tags/items/weapon.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:swords"
+  ]
+}


### PR DESCRIPTION
現在使用者可以透過 Datapack 或 KubeJS 等方式，為物品新增 `#remodifier/weapon` 標籤。

被標記為 `#remodifier/weapon` 的物品將套用 weapon 詞綴（前提是 `WhetherOrNotWeaponUseToolModifiers` 為 `false`）。
若該物品同時屬於 `DiggerItem`，則會在 tool 與 weapon 之間擇一套用詞綴。

## 範例：

使小刀與暮色森林的戰斧套用 weapon 標籤。

### Kubejs

```js
// .minecraft/kubejs/server_scripts/remodifier_weapon_tag.js
ServerEvents.tags('item', event => {
  event.add('remodifier:weapon', [
    "twilightforest:gold_minotaur_axe",
    "twilightforest:diamond_minotaur_axe",
    "twilightforest:knightmetal_pickaxe",
    "twilightforest:knightmetal_axe",
    "#forge:tools/knives",
  ])
})
```

### Datapack

`data/remodifier/tags/items/weapon.json`

```json
{
  "replace": false,
  "values": [
    "twilightforest:gold_minotaur_axe",
    "twilightforest:diamond_minotaur_axe",
    "twilightforest:knightmetal_pickaxe",
    "twilightforest:knightmetal_axe",
    "#forge:tools/knives",
  ]
}
```
